### PR TITLE
fix keep refreshing partitions issue

### DIFF
--- a/src/jvm/storm/kafka/trident/GlobalPartitionInformation.java
+++ b/src/jvm/storm/kafka/trident/GlobalPartitionInformation.java
@@ -64,4 +64,30 @@ public class GlobalPartitionInformation implements Iterable<Partition>, Serializ
             }
         };
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((partitionMap == null) ? 0 : partitionMap.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        GlobalPartitionInformation other = (GlobalPartitionInformation) obj;
+        if (partitionMap == null) {
+            if (other.partitionMap != null)
+                return false;
+        } else if (!partitionMap.equals(other.partitionMap))
+            return false;
+        return true;
+    }
 }


### PR DESCRIPTION
In the emitBatch method of PartitionedTridentSpoutExecutor.Emitter, Trident will try to check whether the "_savedCoordinatorMeta" is updated or not by calling ".equals()" method.
But unfortunately, the meta here is the instance of GlobalPartitionInformation, who hasn't override the equals method, so it will directly calling Object.equals().
Thus, even two GlobalPartitionInformation has same broker information, the equals() will return false, and trident will call the _emitter.refreshPartitions method again and again.
