### PR TITLE
Make the spout's Storm metrics time bucket size configurable via TridentKafkaConfig. Leave the default time bucket size at 60 seconds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.wurstmeister.storm</groupId>
     <artifactId>storm-kafka-0.8-plus</artifactId>
     <packaging>jar</packaging>
-    <version>0.4.0-configurable-metrics-emit-interval-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <name>storm-kafka-0.8-plus</name>
     <description>Storm module for kafka &gt; 0.8</description>
     <licenses>
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>storm</groupId>
             <artifactId>storm</artifactId>
-            <version>0.9.0.1</version>
+            <version>0.9.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>net.wurstmeister.storm</groupId>
     <artifactId>storm-kafka-0.8-plus</artifactId>
     <packaging>jar</packaging>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.4.0-configurable-metrics-emit-interval-SNAPSHOT</version>
     <name>storm-kafka-0.8-plus</name>
     <description>Storm module for kafka &gt; 0.8</description>
     <licenses>
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>storm</groupId>
             <artifactId>storm</artifactId>
-            <version>0.9.0</version>
+            <version>0.9.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/jvm/storm/kafka/KafkaConfig.java
+++ b/src/jvm/storm/kafka/KafkaConfig.java
@@ -18,6 +18,7 @@ public class KafkaConfig implements Serializable {
     public boolean forceFromStart = false;
     public long startOffsetTime = kafka.api.OffsetRequest.EarliestTime();
     public boolean useStartOffsetTimeIfOffsetOutOfRange = true;
+    public int metricsTimeBucketSizeInSecs = 60;
 
     public KafkaConfig(BrokerHosts hosts, String topic) {
         this(hosts, topic, kafka.api.OffsetRequest.DefaultClientId());

--- a/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
@@ -49,9 +49,9 @@ public class TridentKafkaEmitter {
         _connections = new DynamicPartitionConnections(_config, KafkaUtils.makeBrokerReader(conf, _config));
         _topologyName = (String) conf.get(Config.TOPOLOGY_NAME);
         _kafkaOffsetMetric = new KafkaUtils.KafkaOffsetMetric(_config.topic, _connections);
-        context.registerMetric("kafkaOffset", _kafkaOffsetMetric, 60);
-        _kafkaMeanFetchLatencyMetric = context.registerMetric("kafkaFetchAvg", new MeanReducer(), 60);
-        _kafkaMaxFetchLatencyMetric = context.registerMetric("kafkaFetchMax", new MaxMetric(), 60);
+        context.registerMetric("kafkaOffset", _kafkaOffsetMetric, _config.metricsTimeBucketSizeInSecs);
+        _kafkaMeanFetchLatencyMetric = context.registerMetric("kafkaFetchAvg", new MeanReducer(), _config.metricsTimeBucketSizeInSecs);
+        _kafkaMaxFetchLatencyMetric = context.registerMetric("kafkaFetchMax", new MaxMetric(), _config.metricsTimeBucketSizeInSecs);
     }
 
 


### PR DESCRIPTION
Hi!

Please consider merging this pull request. It makes the metrics time bucket size configurable, as it adds more flexibility when pushing the spout's metrics into external systems, like Graphite and Statsd, where the default time bucket size of 60 is too high for some uses. The changes needed are  trivial.

Thanks,

Danijel
