### PR TITLE
Optionally emit kafka key

### DIFF
--- a/src/jvm/storm/kafka/KafkaConfig.java
+++ b/src/jvm/storm/kafka/KafkaConfig.java
@@ -2,6 +2,7 @@ package storm.kafka;
 
 import backtype.storm.spout.MultiScheme;
 import backtype.storm.spout.RawMultiScheme;
+import backtype.storm.spout.Scheme;
 
 import java.io.Serializable;
 
@@ -14,6 +15,7 @@ public class KafkaConfig implements Serializable {
     public int fetchSizeBytes = 1024 * 1024;
     public int socketTimeoutMs = 10000;
     public int bufferSizeBytes = 1024 * 1024;
+    public Scheme keyScheme = null;
     public MultiScheme scheme = new RawMultiScheme();
     public boolean forceFromStart = false;
     public long startOffsetTime = kafka.api.OffsetRequest.EarliestTime();

--- a/src/jvm/storm/kafka/trident/OpaqueTridentKafkaSpout.java
+++ b/src/jvm/storm/kafka/trident/OpaqueTridentKafkaSpout.java
@@ -5,6 +5,8 @@ import backtype.storm.tuple.Fields;
 import storm.kafka.Partition;
 import storm.trident.spout.IOpaquePartitionedTridentSpout;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -31,6 +33,12 @@ public class OpaqueTridentKafkaSpout implements IOpaquePartitionedTridentSpout<G
 
     @Override
     public Fields getOutputFields() {
+        if (_config.keyScheme != null) {
+            List<String> fields = new ArrayList<String>();
+            fields.addAll(_config.scheme.getOutputFields().toList());
+            fields.addAll(_config.keyScheme.getOutputFields().toList());
+            return new Fields(fields);
+        }
         return _config.scheme.getOutputFields();
     }
 

--- a/src/jvm/storm/kafka/trident/TransactionalTridentKafkaSpout.java
+++ b/src/jvm/storm/kafka/trident/TransactionalTridentKafkaSpout.java
@@ -5,11 +5,14 @@ import backtype.storm.tuple.Fields;
 import storm.kafka.Partition;
 import storm.trident.spout.IPartitionedTridentSpout;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 
 public class TransactionalTridentKafkaSpout implements IPartitionedTridentSpout<GlobalPartitionInformation, Partition, Map> {
+    private static final String KEY_FIELD = "key";
 
     TridentKafkaConfig _config;
     String _topologyInstanceId = UUID.randomUUID().toString();
@@ -31,7 +34,14 @@ public class TransactionalTridentKafkaSpout implements IPartitionedTridentSpout<
 
     @Override
     public Fields getOutputFields() {
+        if (_config.keyScheme != null) {
+            List<String> fields = new ArrayList<String>();
+            fields.addAll(_config.scheme.getOutputFields().toList());
+            fields.addAll(_config.keyScheme.getOutputFields().toList());
+            return new Fields(fields);
+        }
         return _config.scheme.getOutputFields();
+
     }
 
     @Override

--- a/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
+++ b/src/jvm/storm/kafka/trident/TridentKafkaEmitter.java
@@ -157,9 +157,22 @@ public class TridentKafkaEmitter {
     private void emit(TridentCollector collector, Message msg) {
         Iterable<List<Object>> values =
                 _config.scheme.deserialize(Utils.toByteArray(msg.payload()));
-        if (values != null) {
-            for (List<Object> value : values) {
-                collector.emit(value);
+
+        if (_config.keyScheme != null) {
+            List<Object> keys =
+                    _config.keyScheme.deserialize(Utils.toByteArray(msg.key()));
+
+            if (values != null) {
+                for (List<Object> value : values) {
+                    value.addAll(keys);
+                    collector.emit(value);
+                }
+            }
+        } else {
+            if (values != null) {
+                for (List<Object> value : values) {
+                    collector.emit(value);
+                }
             }
         }
     }


### PR DESCRIPTION
I want to access the key (not just the payload) that is sent by the Producer in the KeyedMessage.

Pull request modifies KafkaConfig to allow for an optional keyScheme, if set the spouts will include key field(s) and the emitter will emit the deserialized key along with the payload.

Default behaviour is unchanged.
