### PR TITLE
modify partitioning across tasks in ZkCoordinator

### DIFF
--- a/src/jvm/storm/kafka/ZkCoordinator.java
+++ b/src/jvm/storm/kafka/ZkCoordinator.java
@@ -92,7 +92,6 @@ public class ZkCoordinator implements PartitionCoordinator {
     }
 
     private boolean myOwnership(Partition id) {
-        int val = Math.abs(id.host.hashCode() + 23 * id.partition);
-        return val % _totalTasks == _taskIndex;
+        return id.partition % _totalTasks == _taskIndex;
     }
 }


### PR DESCRIPTION
We ran into the same issue as is described in #4 when using KafkaSpout. When attempting to consume from multiple partitions (via multiple spouts), there was no consistency with how the partitions would be assigned to each spout task. Specifically, with an 8 partition topic being consumed from 2 to 8 spouts we would end up with only 1-3 out of the spouts being used.

My small change simplifies the partitioning scheme for KafkaSpout and this has worked for us to distribute consumption from all partitions. I feel like I'm missing something about how `myOwnership` was implemented before though so if that's the case then please enlighten me :).
